### PR TITLE
Fix "Consider dict comprehensions instead of using 'dict()'" issue

### DIFF
--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -40,7 +40,7 @@ class TestWrappedCallableTask(unittest.TestCase):
 
     def test_passes_unused_kwargs_to_parent(self):
         random_range = range(random.randint(1, 10))
-        kwargs = dict([("key_%s" % i, i) for i in random_range])
+        kwargs = {"key_%s" % i: i for i in random_range}
 
         def foo(): pass
         try:
@@ -55,7 +55,7 @@ class TestWrappedCallableTask(unittest.TestCase):
         task = WrappedCallableTask(foo, *args)
 
     def test_allows_any_number_of_kwargs(self):
-        kwargs = dict([("key%d" % i, i) for i in range(random.randint(0, 10))])
+        kwargs = {"key%d" % i: i for i in range(random.randint(0, 10))}
         def foo(): pass
         task = WrappedCallableTask(foo, **kwargs)
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Consider dict comprehensions instead of using 'dict()'](https://www.quantifiedcode.com/app/issue_class/539Wia7V)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:fabric?groups=code_patterns/%3A539Wia7V](https://www.quantifiedcode.com/app/project/gh:runt18:fabric?groups=code_patterns/%3A539Wia7V)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
