### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/fabfile/__init__.py
+++ b/fabfile/__init__.py
@@ -19,6 +19,6 @@ def test(args=None):
     # Default to explicitly targeting the 'tests' folder, but only if nothing
     # is being overridden.
     tests = "" if args else " tests"
-    default_args = "-sv --with-doctest --nologcapture --with-color %s" % tests
+    default_args = "-sv --with-doctest --nologcapture --with-color {0!s}".format(tests)
     default_args += (" " + args) if args else ""
     nose.core.run_exit(argv=[''] + default_args.split())

--- a/fabric/colors.py
+++ b/fabric/colors.py
@@ -30,8 +30,8 @@ def _wrap_with(code):
     def inner(text, bold=False):
         c = code
         if bold:
-            c = "1;%s" % c
-        return "\033[%sm%s\033[0m" % (c, text)
+            c = "1;{0!s}".format(c)
+        return "\033[{0!s}m{1!s}\033[0m".format(c, text)
     return inner
 
 red = _wrap_with('31')

--- a/fabric/context_managers.py
+++ b/fabric/context_managers.py
@@ -540,12 +540,11 @@ def remote_tunnel(remote_port, local_port=None, local_host="localhost",
         try:
             sock.connect((local_host, local_port))
         except Exception, e:
-            print "[%s] rtunnel: cannot connect to %s:%d (from local)" % (env.host_string, local_host, local_port)
+            print "[{0!s}] rtunnel: cannot connect to {1!s}:{2:d} (from local)".format(env.host_string, local_host, local_port)
             channel.close()
             return
 
-        print "[%s] rtunnel: opened reverse tunnel: %r -> %r -> %r"\
-              % (env.host_string, channel.origin_addr,
+        print "[{0!s}] rtunnel: opened reverse tunnel: {1!r} -> {2!r} -> {3!r}".format(env.host_string, channel.origin_addr,
                  channel.getpeername(), (local_host, local_port))
 
         th = ThreadHandler('fwd', _forwarder, channel, sock)

--- a/fabric/contrib/console.py
+++ b/fabric/contrib/console.py
@@ -24,7 +24,7 @@ def confirm(question, default=True):
         suffix = "y/N"
     # Loop till we get something we like
     while True:
-        response = prompt("%s [%s] " % (question, suffix)).lower()
+        response = prompt("{0!s} [{1!s}] ".format(question, suffix)).lower()
         # Default
         if not response:
             return default

--- a/fabric/contrib/django.py
+++ b/fabric/contrib/django.py
@@ -91,4 +91,4 @@ def project(name):
     Uses `settings_module` -- see its documentation for details on why and how
     to use this functionality.
     """
-    settings_module('%s.settings' % name)
+    settings_module('{0!s}.settings'.format(name))

--- a/fabric/contrib/project.py
+++ b/fabric/contrib/project.py
@@ -114,12 +114,12 @@ def rsync_project(
         key_string = "-i " + " -i ".join(keys)
     # Port
     user, host, port = normalize(env.host_string)
-    port_string = "-p %s" % port
+    port_string = "-p {0!s}".format(port)
     # RSH
     rsh_string = ""
     rsh_parts = [key_string, port_string, ssh_opts]
     if any(rsh_parts):
-        rsh_string = "--rsh='ssh %s'" % " ".join(rsh_parts)
+        rsh_string = "--rsh='ssh {0!s}'".format(" ".join(rsh_parts))
     # Set up options part of string
     options_map = {
         'delete': '--delete' if delete else '',
@@ -128,7 +128,7 @@ def rsync_project(
         'default': default_opts,
         'extra': extra_opts,
     }
-    options = "%(delete)s%(exclude)s %(default)s %(extra)s %(rsh)s" % options_map
+    options = "{delete!s}{exclude!s} {default!s} {extra!s} {rsh!s}".format(**options_map)
     # Get local directory
     if local_dir is None:
         local_dir = '../' + getcwd().split(sep)[-1]
@@ -136,16 +136,16 @@ def rsync_project(
     if host.count(':') > 1:
         # Square brackets are mandatory for IPv6 rsync address,
         # even if port number is not specified
-        remote_prefix = "[%s@%s]" % (user, host)
+        remote_prefix = "[{0!s}@{1!s}]".format(user, host)
     else:
-        remote_prefix = "%s@%s" % (user, host)
+        remote_prefix = "{0!s}@{1!s}".format(user, host)
     if upload:
-        cmd = "rsync %s %s %s:%s" % (options, local_dir, remote_prefix, remote_dir)
+        cmd = "rsync {0!s} {1!s} {2!s}:{3!s}".format(options, local_dir, remote_prefix, remote_dir)
     else:
-        cmd = "rsync %s %s:%s %s" % (options, remote_prefix, remote_dir, local_dir)
+        cmd = "rsync {0!s} {1!s}:{2!s} {3!s}".format(options, remote_prefix, remote_dir, local_dir)
 
     if output.running:
-        print("[%s] rsync_project: %s" % (env.host_string, cmd))
+        print("[{0!s}] rsync_project: {1!s}".format(env.host_string, cmd))
     return local(cmd, capture=capture)
 
 
@@ -183,18 +183,18 @@ def upload_project(local_dir=None, remote_dir="", use_sudo=False):
     local_dir = local_dir.rstrip(os.sep)
 
     local_path, local_name = os.path.split(local_dir)
-    tar_file = "%s.tar.gz" % local_name
+    tar_file = "{0!s}.tar.gz".format(local_name)
     target_tar = os.path.join(remote_dir, tar_file)
     tmp_folder = mkdtemp()
 
     try:
         tar_path = os.path.join(tmp_folder, tar_file)
-        local("tar -czf %s -C %s %s" % (tar_path, local_path, local_name))
+        local("tar -czf {0!s} -C {1!s} {2!s}".format(tar_path, local_path, local_name))
         put(tar_path, target_tar, use_sudo=use_sudo)
         with cd(remote_dir):
             try:
-                runner("tar -xzf %s" % tar_file)
+                runner("tar -xzf {0!s}".format(tar_file))
             finally:
-                runner("rm -f %s" % tar_file)
+                runner("rm -f {0!s}".format(tar_file))
     finally:
-        local("rm -rf %s" % tmp_folder)
+        local("rm -rf {0!s}".format(tmp_folder))

--- a/fabric/docs.py
+++ b/fabric/docs.py
@@ -53,5 +53,5 @@ def unwrap_tasks(module, hide_nontasks=False):
                 continue
             has_docstring = getattr(obj, '__doc__', False)
             if hide_nontasks and has_docstring and not name.startswith('_'):
-                setattr(module, '_%s' % name, obj)
+                setattr(module, '_{0!s}'.format(name), obj)
                 delattr(module, name)

--- a/fabric/exceptions.py
+++ b/fabric/exceptions.py
@@ -18,7 +18,7 @@ class NetworkError(Exception):
         return self.message or ""
 
     def __repr__(self):
-        return "%s(%s) => %r" % (
+        return "{0!s}({1!s}) => {2!r}".format(
             self.__class__.__name__, self.message, self.wrapped
         )
 
@@ -27,6 +27,6 @@ class CommandTimeout(Exception):
     def __init__(self, timeout):
         self.timeout = timeout
 
-        message = 'Command failed to finish in %s seconds' % (timeout)
+        message = 'Command failed to finish in {0!s} seconds'.format((timeout))
         self.message = message
         super(CommandTimeout, self).__init__(message)

--- a/fabric/io.py
+++ b/fabric/io.py
@@ -39,7 +39,7 @@ class OutputLooper(object):
         self.capture = capture
         self.timeout = timeout
         self.read_func = getattr(chan, attr)
-        self.prefix = "[%s] %s: " % (
+        self.prefix = "[{0!s}] {1!s}: ".format(
             env.host_string,
             "out" if attr == 'recv' else "err"
         )

--- a/fabric/job_queue.py
+++ b/fabric/job_queue.py
@@ -88,7 +88,7 @@ class JobQueue(object):
             self._queued.append(process)
             self._num_of_jobs += 1
             if self._debug:
-                print("job queue appended %s." % process.name)
+                print("job queue appended {0!s}.".format(process.name))
 
     def run(self):
         """
@@ -117,7 +117,7 @@ class JobQueue(object):
             """
             job = self._queued.pop()
             if self._debug:
-                print("Popping '%s' off the queue and starting it" % job.name)
+                print("Popping '{0!s}' off the queue and starting it".format(job.name))
             with settings(clean_revert=True, host_string=job.name, host=job.name):
                 job.start()
             self._running.append(job)
@@ -145,13 +145,13 @@ class JobQueue(object):
                 for id, job in enumerate(self._running):
                     if not job.is_alive():
                         if self._debug:
-                            print("Job queue found finished proc: %s." %
-                                    job.name)
+                            print("Job queue found finished proc: {0!s}.".format(
+                                    job.name))
                         done = self._running.pop(id)
                         self._completed.append(done)
 
                 if self._debug:
-                    print("Job queue has %d running." % len(self._running))
+                    print("Job queue has {0:d} running.".format(len(self._running)))
 
             if not (self._queued or self._running):
                 if self._debug:

--- a/fabric/main.py
+++ b/fabric/main.py
@@ -291,7 +291,7 @@ def parse_options():
         choices=LIST_FORMAT_OPTIONS,
         default='normal',
         metavar='FORMAT',
-        help="formats --list, choices: %s" % ", ".join(LIST_FORMAT_OPTIONS)
+        help="formats --list, choices: {0!s}".format(", ".join(LIST_FORMAT_OPTIONS))
     )
 
     parser.add_option('-I', '--initial-password-prompt',
@@ -478,13 +478,13 @@ def display_command(name):
     else:
         task_details = get_task_details(command)
     if task_details:
-        print("Displaying detailed information for task '%s':" % name)
+        print("Displaying detailed information for task '{0!s}':".format(name))
         print('')
         print(indent(task_details, strip=True))
         print('')
     # Or print notice if not
     else:
-        print("No detailed information available for task '%s':" % name)
+        print("No detailed information available for task '{0!s}':".format(name))
     sys.exit(0)
 
 
@@ -495,7 +495,7 @@ def _escape_split(sep, argstr):
     It should be noted that the way bash et. al. do command line parsing, those
     single quotes are required.
     """
-    escaped_sep = r'\%s' % sep
+    escaped_sep = r'\{0!s}'.format(sep)
 
     if escaped_sep not in argstr:
         return argstr.split(sep)
@@ -633,8 +633,8 @@ def main(fabfile_locations=None):
 
         # Handle version number option
         if options.show_version:
-            print("Fabric %s" % state.env.version)
-            print("Paramiko %s" % ssh.__version__)
+            print("Fabric {0!s}".format(state.env.version))
+            print("Paramiko {0!s}".format(ssh.__version__))
             sys.exit(0)
 
         # Load settings from user settings file, into shared env dict.
@@ -673,7 +673,7 @@ Remember that -f can be used to specify fabfile path, and use -h for help.""")
         # Now that we're settled on a fabfile, inform user.
         if state.output.debug:
             if fabfile:
-                print("Using fabfile '%s'" % fabfile)
+                print("Using fabfile '{0!s}'".format(fabfile))
             else:
                 print("No fabfile loaded -- remainder command only")
 
@@ -710,8 +710,7 @@ Remember that -f can be used to specify fabfile path, and use -h for help.""")
 
         # Abort if any unknown commands were specified
         if unknown_commands and not state.env.get('skip_unknown_tasks', False):
-            warn("Command(s) not found:\n%s" \
-                % indent(unknown_commands))
+            warn("Command(s) not found:\n{0!s}".format(indent(unknown_commands)))
             show_commands(None, options.list_format, 1)
 
         # Generate remainder command and insert into commands, commands_to_run
@@ -731,7 +730,7 @@ Remember that -f can be used to specify fabfile path, and use -h for help.""")
 
         if state.output.debug:
             names = ", ".join(x[0] for x in commands_to_run)
-            print("Commands to run: %s" % names)
+            print("Commands to run: {0!s}".format(names))
 
         # At this point all commands must exist, so execute them in order.
         for name, args, kwargs, arg_hosts, arg_roles, arg_exclude_hosts in commands_to_run:

--- a/fabric/network.py
+++ b/fabric/network.py
@@ -89,7 +89,7 @@ def get_gateway(host, port, cache, replace=False):
         # ensure initial gateway connection
         if replace or gateway not in cache:
             if output.debug:
-                print "Creating new gateway connection to %r" % gateway
+                print "Creating new gateway connection to {0!r}".format(gateway)
             cache[gateway] = connect(*normalize(gateway) + (cache, False))
         # now we should have an open gw connection and can ask it for a
         # direct-tcpip channel to the real target. (bypass cache's own
@@ -197,7 +197,7 @@ def ssh_config(host_string=None):
                 conf.parse(fd)
                 env._ssh_config = conf
         except IOError:
-            warn("Unable to load SSH config file '%s'" % path)
+            warn("Unable to load SSH config file '{0!s}'".format(path))
             return dummy
     host = parse_host_string(host_string or env.host_string)['host']
     return env._ssh_config.lookup(host)
@@ -237,10 +237,10 @@ def key_from_env(passphrase=None):
             # NOTE: this may not be the most secure thing; OTOH anybody running
             # the process must by definition have access to the key value,
             # so only serious problem is if they're logging the output.
-            sys.stderr.write("Trying to honor in-memory key %r\n" % env.key)
+            sys.stderr.write("Trying to honor in-memory key {0!r}\n".format(env.key))
         for pkey_class in (ssh.rsakey.RSAKey, ssh.dsskey.DSSKey):
             if output.debug:
-                sys.stderr.write("Trying to load it as %s\n" % pkey_class)
+                sys.stderr.write("Trying to load it as {0!s}\n".format(pkey_class))
             try:
                 return pkey_class.from_private_key(StringIO(env.key), passphrase)
             except Exception, e:
@@ -347,7 +347,7 @@ def denormalize(host_string):
     if r['port'] is not None and r['port'] != '22':
         port = ':' + r['port']
     host = r['host']
-    host = '[%s]' % host if port and host.count(':') > 1 else host
+    host = '[{0!s}]'.format(host) if port and host.count(':') > 1 else host
     return user + host + port
 
 
@@ -368,7 +368,7 @@ def join_host_strings(user, host, port=None):
         template = "%s@[%s]:%s" if host.count(':') > 1 else "%s@%s:%s"
         return template % (user, host, port)
     else:
-        return "%s@%s" % (user, host)
+        return "{0!s}@{1!s}".format(user, host)
 
 
 def normalize_to_string(host_string):
@@ -462,7 +462,7 @@ def connect(user, host, port, cache, seek_gateway=True):
         # command line results in the big banner error about man-in-the-middle
         # attacks.
         except ssh.BadHostKeyException, e:
-            raise NetworkError("Host key for %s did not match pre-existing key! Server's key was changed recently, or possible man-in-the-middle attack." % host, e)
+            raise NetworkError("Host key for {0!s} did not match pre-existing key! Server's key was changed recently, or possible man-in-the-middle attack.".format(host), e)
         # Prompt for new password to try on auth failure
         except (
             ssh.AuthenticationException,
@@ -540,16 +540,16 @@ def connect(user, host, port, cache, seek_gateway=True):
             sys.exit(0)
         # Handle DNS error / name lookup failure
         except socket.gaierror, e:
-            raise NetworkError('Name lookup failed for %s' % host, e)
+            raise NetworkError('Name lookup failed for {0!s}'.format(host), e)
         # Handle timeouts and retries, including generic errors
         # NOTE: In 2.6, socket.error subclasses IOError
         except socket.error, e:
             not_timeout = type(e) is not socket.timeout
             giving_up = _tried_enough(tries)
             # Baseline error msg for when debug is off
-            msg = "Timed out trying to connect to %s" % host
+            msg = "Timed out trying to connect to {0!s}".format(host)
             # Expanded for debug on
-            err = msg + " (attempt %s of %s)" % (tries, env.connection_attempts)
+            err = msg + " (attempt {0!s} of {1!s})".format(tries, env.connection_attempts)
             if giving_up:
                 err += ", giving up"
             err += ")"
@@ -565,13 +565,13 @@ def connect(user, host, port, cache, seek_gateway=True):
                 continue
             # Override eror msg if we were retrying other errors
             if not_timeout:
-                msg = "Low level socket error connecting to host %s on port %s: %s" % (
+                msg = "Low level socket error connecting to host {0!s} on port {1!s}: {2!s}".format(
                     host, port, e[1]
                 )
             # Here, all attempts failed. Tweak error msg to show # tries.
             # TODO: find good humanization module, jeez
             s = "s" if env.connection_attempts > 1 else ""
-            msg += " (tried %s time%s)" % (env.connection_attempts, s)
+            msg += " (tried {0!s} time{1!s})".format(env.connection_attempts, s)
             raise NetworkError(msg, e)
         # Ensure that if we terminated without connecting and we were given an
         # explicit socket, close it out.
@@ -606,7 +606,7 @@ def prompt_for_password(prompt=None, no_colon=False, stream=None):
     handle_prompt_abort("a connection or sudo password")
     stream = stream or sys.stderr
     # Construct prompt
-    default = "[%s] Login password for '%s'" % (env.host_string, env.user)
+    default = "[{0!s}] Login password for '{1!s}'".format(env.host_string, env.user)
     password_prompt = prompt if (prompt is not None) else default
     if not no_colon:
         password_prompt += ": "
@@ -664,7 +664,7 @@ def disconnect_all():
         if output.status:
             # Here we can't use the py3k print(x, end=" ")
             # because 2.5 backwards compatibility
-            sys.stdout.write("Disconnecting from %s... " % denormalize(key))
+            sys.stdout.write("Disconnecting from {0!s}... ".format(denormalize(key)))
         connections[key].close()
         del connections[key]
         if output.status:

--- a/fabric/sftp.py
+++ b/fabric/sftp.py
@@ -109,7 +109,7 @@ class SFTP(object):
         from fabric.api import sudo, hide
         if use_sudo:
             with hide('everything'):
-                sudo('mkdir "%s"' % path)
+                sudo('mkdir "{0!s}"'.format(path))
         else:
             self.ftp.mkdir(path)
 
@@ -143,7 +143,7 @@ class SFTP(object):
                 local_path = os.path.join(local_path, path_vars['basename'])
 
         if output.running:
-            print("[%s] download: %s <- %s" % (
+            print("[{0!s}] download: {1!s} <- {2!s}".format(
                 env.host_string,
                 _format_local(local_path, local_is_path),
                 remote_path
@@ -165,11 +165,11 @@ class SFTP(object):
             # Temporarily nuke 'cwd' so sudo() doesn't "cd" its mv command.
             # (The target path has already been cwd-ified elsewhere.)
             with settings(hide('everything'), cwd=""):
-                sudo('cp -p "%s" "%s"' % (remote_path, target_path))
+                sudo('cp -p "{0!s}" "{1!s}"'.format(remote_path, target_path))
                 # The user should always own the copied file.
-                sudo('chown %s "%s"' % (env.user, target_path))
+                sudo('chown {0!s} "{1!s}"'.format(env.user, target_path))
                 # Only root and the user has the right to read the file
-                sudo('chmod %o "%s"' % (0400, target_path))
+                sudo('chmod {0:o} "{1!s}"'.format(0400, target_path))
                 remote_path = target_path
 
         try:
@@ -184,7 +184,7 @@ class SFTP(object):
             # try to remove the temporary file after the download
             if use_sudo:
                 with settings(hide('everything'), cwd=""):
-                    sudo('rm -f "%s"' % remote_path)
+                    sudo('rm -f "{0!s}"'.format(remote_path))
 
         # Return local_path object for posterity. (If mutated, caller will want
         # to know.)
@@ -239,7 +239,7 @@ class SFTP(object):
             basename = os.path.basename(local_path)
             remote_path = posixpath.join(remote_path, basename)
         if output.running:
-            print("[%s] put: %s -> %s" % (
+            print("[{0!s}] put: {1!s} -> {2!s}".format(
                 env.host_string,
                 _format_local(local_path, local_is_path),
                 posixpath.join(pre, remote_path)
@@ -279,14 +279,14 @@ class SFTP(object):
                     # command. (The target path has already been cwd-ified
                     # elsewhere.)
                     with settings(hide('everything'), cwd=""):
-                        sudo('chmod %o \"%s\"' % (lmode, remote_path))
+                        sudo('chmod {0:o} \"{1!s}\"'.format(lmode, remote_path))
                 else:
                     self.ftp.chmod(remote_path, lmode)
         if use_sudo:
             # Temporarily nuke 'cwd' so sudo() doesn't "cd" its mv command.
             # (The target path has already been cwd-ified elsewhere.)
             with settings(hide('everything'), cwd=""):
-                sudo("mv \"%s\" \"%s\"" % (remote_path, target_path))
+                sudo("mv \"{0!s}\" \"{1!s}\"".format(remote_path, target_path))
             # Revert to original remote_path for return value's sake
             remote_path = target_path
         return remote_path

--- a/fabric/state.py
+++ b/fabric/state.py
@@ -61,7 +61,7 @@ def _rc_path():
     if expanded_rc_path == rc_path and win32:
             from win32com.shell.shell import SHGetSpecialFolderPath
             from win32com.shell.shellcon import CSIDL_PROFILE
-            expanded_rc_path = "%s/%s" % (
+            expanded_rc_path = "{0!s}/{1!s}".format(
                 SHGetSpecialFolderPath(0, CSIDL_PROFILE),
                 rc_file
                 )

--- a/fabric/task_utils.py
+++ b/fabric/task_utils.py
@@ -40,9 +40,9 @@ def merge(hosts, roles, exclude, roledefs):
     # Abort if any roles don't exist
     bad_roles = [x for x in roles if x not in roledefs]
     if bad_roles:
-        abort("The following specified roles do not exist:\n%s" % (
+        abort("The following specified roles do not exist:\n{0!s}".format((
             indent(bad_roles)
-        ))
+        )))
 
     # Coerce strings to one-item lists
     if isinstance(hosts, basestring):

--- a/fabric/tasks.py
+++ b/fabric/tasks.py
@@ -46,13 +46,13 @@ def get_task_details(task):
     args_without_defaults = argspec.args[:len(argspec.args) - num_default_args]
     args_with_defaults = argspec.args[-1 * num_default_args:]
 
-    details.append('Arguments: %s' % (
+    details.append('Arguments: {0!s}'.format((
         ', '.join(
             args_without_defaults + [
-                '%s=%r' % (arg, default)
+                '{0!s}={1!r}'.format(arg, default)
                 for arg, default in zip(args_with_defaults, default_args)
             ])
-    ))
+    )))
 
     return '\n'.join(details)
 
@@ -138,7 +138,7 @@ class Task(object):
         pool_size = min((pool_size, len(hosts)))
         # Inform user of final pool size for this task
         if state.output.debug:
-            print("Parallel tasks now using pool size of %d" % pool_size)
+            print("Parallel tasks now using pool size of {0:d}".format(pool_size))
         return pool_size
 
 
@@ -216,7 +216,7 @@ def _execute(task, host, my_env, args, kwargs, jobs, queue, multiprocessing):
     """
     # Log to stdout
     if state.output.running and not hasattr(task, 'return_value'):
-        print("[%s] Executing task '%s'" % (host, my_env['command']))
+        print("[{0!s}] Executing task '{1!s}'".format(host, my_env['command']))
     # Create per-run env with connection settings
     local_env = to_dict(host)
     local_env.update(my_env)
@@ -249,7 +249,7 @@ def _execute(task, host, my_env, args, kwargs, jobs, queue, multiprocessing):
                 if e.__class__ is not SystemExit:
                     if not (isinstance(e, NetworkError) and
                             _is_network_error_ignored()):
-                        sys.stderr.write("!!! Parallel execution exception under host %r:\n" % name)
+                        sys.stderr.write("!!! Parallel execution exception under host {0!r}:\n".format(name))
                     submit(e)
                 # Here, anything -- unexpected exceptions, or abort()
                 # driven SystemExits -- will bubble up and terminate the
@@ -333,7 +333,7 @@ def execute(task, *args, **kwargs):
         my_env['command'] = task
         task = crawl(task, state.commands)
         if task is None:
-            msg = "%r is not callable or a valid task name" % (my_env['command'],)
+            msg = "{0!r} is not callable or a valid task name".format(my_env['command'])
             if state.env.get('skip_unknown_tasks', False):
                 warn(msg)
                 return
@@ -402,9 +402,9 @@ def execute(task, *args, **kwargs):
 
         # If running in parallel, block until job queue is emptied
         if jobs:
-            err = "One or more hosts failed while executing task '%s'" % (
+            err = "One or more hosts failed while executing task '{0!s}'".format((
                 my_env['command']
-            )
+            ))
             jobs.close()
             # Abort if any children did not exit cleanly (fail-fast).
             # This prevents Fabric from continuing on to any other tasks.

--- a/fabric/utils.py
+++ b/fabric/utils.py
@@ -47,7 +47,7 @@ def abort(msg):
         from colors import red
 
     if output.aborts:
-        sys.stderr.write(red("\nFatal error: %s\n" % _encode(msg, sys.stderr)))
+        sys.stderr.write(red("\nFatal error: {0!s}\n".format(_encode(msg, sys.stderr))))
         sys.stderr.write(red("\nAborting.\n"))
 
     if env.abort_exception:
@@ -80,7 +80,7 @@ def warn(msg):
 
     if output.warnings:
         msg = _encode(msg, sys.stderr)
-        sys.stderr.write(magenta("\nWarning: %s\n\n" % msg))
+        sys.stderr.write(magenta("\nWarning: {0!s}\n\n".format(msg)))
 
 
 def indent(text, spaces=4, strip=False):
@@ -138,7 +138,7 @@ def puts(text, show_prefix=None, end="\n", flush=False):
     if output.user:
         prefix = ""
         if env.host_string and show_prefix:
-            prefix = "[%s] " % env.host_string
+            prefix = "[{0!s}] ".format(env.host_string)
         sys.stdout.write(prefix + _encode(text, sys.stdout) + end)
         if flush:
             sys.stdout.flush()
@@ -172,7 +172,7 @@ def fastprint(text, show_prefix=False, end="", flush=True):
 
 def handle_prompt_abort(prompt_for):
     import fabric.state
-    reason = "Needed to prompt for %s (host: %s), but %%s" % (
+    reason = "Needed to prompt for {0!s} (host: {1!s}), but %s".format(
         prompt_for, fabric.state.env.host_string
     )
     # Explicit "don't prompt me bro"
@@ -363,7 +363,7 @@ def _format_error_output(header, body):
     header_side_length = (term_width - (len(header) + 2)) / 2
     mark = "="
     side = mark * header_side_length
-    return "\n\n%s %s %s\n\n%s\n\n%s" % (
+    return "\n\n{0!s} {1!s} {2!s}\n\n{3!s}\n\n{4!s}".format(
         side, header, side, body, mark * term_width
     )
 

--- a/fabric/version.py
+++ b/fabric/version.py
@@ -16,7 +16,7 @@ def git_sha():
     loc = abspath(dirname(__file__))
     try:
         p = Popen(
-            "cd \"%s\" && git log -1 --format=format:%%h" % loc,
+            "cd \"{0!s}\" && git log -1 --format=format:%h".format(loc),
             shell=True,
             stdout=PIPE,
             stderr=PIPE
@@ -47,7 +47,7 @@ def get_version(form='short'):
     """
     # Setup
     versions = {}
-    branch = "%s.%s" % (VERSION[0], VERSION[1])
+    branch = "{0!s}.{1!s}".format(VERSION[0], VERSION[1])
     tertiary = VERSION[2]
     type_ = VERSION[3]
     final = (type_ == "final")
@@ -96,7 +96,7 @@ def get_version(form='short'):
     except KeyError:
         if form == 'all':
             return versions
-        raise TypeError('"%s" is not a valid form specifier.' % form)
+        raise TypeError('"{0!s}" is not a valid form specifier.'.format(form))
 
 __version__ = get_version('short')
 

--- a/integration/test_contrib.py
+++ b/integration/test_contrib.py
@@ -33,7 +33,7 @@ class FileCleaner(Integration):
         for created in self.local:
             os.unlink(created)
         for created in self.remote:
-            run("rm %s" % escape(created))
+            run("rm {0!s}".format(escape(created)))
 
 
 class TestTildeExpansion(FileCleaner):
@@ -46,13 +46,13 @@ class TestTildeExpansion(FileCleaner):
     def test_exists(self):
         for target in ('~/exists_test', '~/exists test with space'):
             self.remote.append(target)
-            run("touch %s" % escape(target))
+            run("touch {0!s}".format(escape(target)))
             expect(target)
      
     def test_sed(self):
         for target in ('~/sed_test', '~/sed test with space'):
             self.remote.append(target)
-            run("echo 'before' > %s" % escape(target))
+            run("echo 'before' > {0!s}".format(escape(target)))
             files.sed(target, 'before', 'after')
             expect_contains(target, 'after')
      
@@ -61,8 +61,8 @@ class TestTildeExpansion(FileCleaner):
             '~/upload_template_test',
             '~/upload template test with space'
         )):
-            src = "source%s" % i
-            local("touch %s" % src)
+            src = "source{0!s}".format(i)
+            local("touch {0!s}".format(src))
             self.local.append(src)
             self.remote.append(target)
             files.upload_template(src, target)
@@ -92,9 +92,9 @@ rsync_sources = (
 
 class TestRsync(Integration):
     def rsync(self, id_, **kwargs):
-        remote = '/tmp/rsync-test-%s/' % id_
+        remote = '/tmp/rsync-test-{0!s}/'.format(id_)
         if files.exists(remote):
-            run("rm -rf %s" % remote)
+            run("rm -rf {0!s}".format(remote))
         return project.rsync_project(
             remote_dir=remote,
             local_dir='integration',
@@ -109,7 +109,7 @@ class TestRsync(Integration):
         """
         r = self.rsync(1)
         for x in rsync_sources:
-            assert re.search(r'^%s$' % x, r.stdout, re.M), "'%s' was not found in '%s'" % (x, r.stdout)
+            assert re.search(r'^{0!s}$'.format(x), r.stdout, re.M), "'{0!s}' was not found in '{1!s}'".format(x, r.stdout)
 
     def test_overriding_default_args(self):
         """
@@ -117,14 +117,14 @@ class TestRsync(Integration):
         """
         r = self.rsync(2, default_opts='-pthrz')
         for x in rsync_sources:
-            assert not re.search(r'^%s$' % x, r.stdout, re.M), "'%s' was found in '%s'" % (x, r.stdout)
+            assert not re.search(r'^{0!s}$'.format(x), r.stdout, re.M), "'{0!s}' was found in '{1!s}'".format(x, r.stdout)
 
 
 class TestUploadTemplate(FileCleaner):
     def test_allows_pty_disable(self):
         src = "source_file"
         target = "remote_file"
-        local("touch %s" % src)
+        local("touch {0!s}".format(src))
         self.local.append(src)
         self.remote.append(target)
         # Just make sure it doesn't asplode. meh.

--- a/setup.py
+++ b/setup.py
@@ -22,12 +22,12 @@ pip, with `pip install fabric==dev`.
 
 ----
 
-%s
+{0!s}
 
 ----
 
 For more information, please see the Fabric website or execute ``fab --help``.
-""" % (readme)
+""".format((readme))
 
 if sys.version_info[:2] < (2, 6):
     install_requires=['paramiko>=1.10,<1.13']

--- a/sites/shared_conf.py
+++ b/sites/shared_conf.py
@@ -36,7 +36,7 @@ html_sidebars = {
 # Regular settings
 project = 'Fabric'
 year = datetime.now().year
-copyright = '%d Jeff Forcier' % year
+copyright = '{0:d} Jeff Forcier'.format(year)
 master_doc = 'index'
 templates_path = ['_templates']
 exclude_trees = ['_build']

--- a/tests/Python26SocketServer.py
+++ b/tests/Python26SocketServer.py
@@ -330,7 +330,7 @@ class BaseServer:
 
         """
         print('-' * 40)
-        print('Exception happened during processing of request from %s' % (client_address,))
+        print('Exception happened during processing of request from {0!s}'.format(client_address))
         import traceback
         traceback.print_exc()  # XXX But this goes to stderr!
         print('-' * 40)
@@ -510,8 +510,7 @@ class ForkingMixIn:
             try:
                 self.active_children.remove(pid)
             except ValueError, e:
-                raise ValueError('%s. x=%d and list=%r' % \
-                                    (e.message, pid, self.active_children))
+                raise ValueError('{0!s}. x={1:d} and list={2!r}'.format(e.message, pid, self.active_children))
 
     def handle_timeout(self):
         """Wait for zombies after self.timeout seconds of inactivity.

--- a/tests/server.py
+++ b/tests/server.py
@@ -400,7 +400,7 @@ def serve_responses(responses, files, passwords, home, pubkeys, port):
 
         def split_sudo_prompt(self):
             prefix = re.escape(_sudo_prefix(None, None).rstrip()) + ' +'
-            result = re.findall(r'^(%s)?(.*)$' % prefix, self.command)[0]
+            result = re.findall(r'^({0!s})?(.*)$'.format(prefix), self.command)[0]
             self.sudo_prompt, self.command = result
 
         def response(self):

--- a/tests/test_context_managers.py
+++ b/tests/test_context_managers.py
@@ -122,7 +122,7 @@ def test_cd_prefix():
 
     with cd(some_path):
         command_out = _prefix_commands('foo', "remote")
-        eq_(command_out, 'cd %s >/dev/null && foo' % some_path)
+        eq_(command_out, 'cd {0!s} >/dev/null && foo'.format(some_path))
 
 
 # def test_cd_prefix_on_win32():

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -574,7 +574,7 @@ def test_list_output():
         debian:
             update_apt"""),
     ):
-        list_output.description = "--list output: %s" % desc
+        list_output.description = "--list output: {0!s}".format(desc)
         yield list_output, module, format_, expected
         del list_output.description
 
@@ -623,7 +623,7 @@ def test_task_names():
             ['h', 'z', 'b.c', 'b.g', 'b.d.e.f', 'w.y']
         ),
     ):
-        eq_.description = "task name flattening: %s" % desc
+        eq_.description = "task name flattening: {0!s}".format(desc)
         yield eq_, _task_names(strings_to_tasks(input_)), output
         del eq_.description
 
@@ -635,7 +635,7 @@ def test_crawl():
         ("deep", 'a.b.c.d.e', {'a': {'b': {'c': {'d': {'e': 5}}}}}, 5),
         ("full tree", 'a.b.c', {'a': {'b': {'c': 5}, 'd': 6}, 'z': 7}, 5)
     ):
-        eq_.description = "crawling dotted names: %s" % desc
+        eq_.description = "crawling dotted names: {0!s}".format(desc)
         yield eq_, _crawl(name, mapping), output
         del eq_.description
 
@@ -662,7 +662,7 @@ mymodule.long_task_name"""),
     mymodule:
         long_task_name""")
     ):
-        list_output.description = "Default task --list output: %s" % format_
+        list_output.description = "Default task --list output: {0!s}".format(format_)
         yield list_output, 'default_tasks', format_, expected
         del list_output.description
 

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -43,7 +43,7 @@ class TestNetwork(FabricTest):
             ("Both username and port tested at once, for kicks",
                 'localhost', username + '@localhost:22'),
         ):
-            eq_.description = "Host-string normalization: %s" % description
+            eq_.description = "Host-string normalization: {0!s}".format(description)
             yield eq_, normalize(input), normalize(output_)
             del eq_.description
 
@@ -66,7 +66,7 @@ class TestNetwork(FabricTest):
             ("Username and IPv6 address with non-standard port",
                 'user@[2001:DB8::1]:1222', ('user', '2001:DB8::1', '1222')),
         ):
-            eq_.description = "Host-string IPv6 normalization: %s" % description
+            eq_.description = "Host-string IPv6 normalization: {0!s}".format(description)
             yield eq_, normalize(input), output_
             del eq_.description
 
@@ -138,7 +138,7 @@ class TestNetwork(FabricTest):
             ("IPv6 address",
                 '2001:DB8::1', username + '@[2001:DB8::1]:22'),
         ):
-            eq_.description = "Host-string denormalization: %s" % description
+            eq_.description = "Host-string denormalization: {0!s}".format(description)
             yield eq_, denormalize(string1), denormalize(string2)
             del eq_.description
 
@@ -258,7 +258,7 @@ class TestNetwork(FabricTest):
         cmd = "ls /"
         output_string = RESPONSES[cmd]
         # TODO: fix below lines, duplicates inner workings of tested code
-        prefix = "[%s] out: " % env.host_string
+        prefix = "[{0!s}] out: ".format(env.host_string)
         expected = prefix + ('\n' + prefix).join(output_string.split('\n'))
         # Create, tie off thread
         with settings(show('everything'), hide('running')):
@@ -324,7 +324,7 @@ class TestNetwork(FabricTest):
         output.everything = False
         with password_response(PASSWORDS[env.user], silent=False):
             run("ls /simple")
-        regex = r'^\[%s\] Login password for \'%s\': ' % (env.host_string, env.user)
+        regex = r'^\[{0!s}\] Login password for \'{1!s}\': '.format(env.host_string, env.user)
         assert_contains(regex, sys.stderr.getvalue())
 
     @mock_streams('stderr')
@@ -339,7 +339,7 @@ class TestNetwork(FabricTest):
         output.everything = False
         with password_response(CLIENT_PRIVKEY_PASSPHRASE, silent=False):
             run("ls /simple")
-        regex = r'^\[%s\] Login password for \'%s\': ' % (env.host_string, env.user)
+        regex = r'^\[{0!s}\] Login password for \'{1!s}\': '.format(env.host_string, env.user)
         assert_contains(regex, sys.stderr.getvalue())
 
     def test_sudo_prompt_display_passthrough(self):
@@ -369,24 +369,24 @@ class TestNetwork(FabricTest):
             sudo('oneliner')
         if display_output:
             expected = """
-[%(prefix)s] sudo: oneliner
-[%(prefix)s] Login password for '%(user)s': 
-[%(prefix)s] out: sudo password:
-[%(prefix)s] out: Sorry, try again.
-[%(prefix)s] out: sudo password: 
-[%(prefix)s] out: result
-""" % {'prefix': env.host_string, 'user': env.user}
+[{prefix!s}] sudo: oneliner
+[{prefix!s}] Login password for '{user!s}': 
+[{prefix!s}] out: sudo password:
+[{prefix!s}] out: Sorry, try again.
+[{prefix!s}] out: sudo password: 
+[{prefix!s}] out: result
+""".format(**{'prefix': env.host_string, 'user': env.user})
         else:
             # Note lack of first sudo prompt (as it's autoresponded to) and of
             # course the actual result output.
             expected = """
-[%(prefix)s] sudo: oneliner
-[%(prefix)s] Login password for '%(user)s': 
-[%(prefix)s] out: Sorry, try again.
-[%(prefix)s] out: sudo password: """ % {
+[{prefix!s}] sudo: oneliner
+[{prefix!s}] Login password for '{user!s}': 
+[{prefix!s}] out: Sorry, try again.
+[{prefix!s}] out: sudo password: """.format(**{
     'prefix': env.host_string,
     'user': env.user
-}
+})
         eq_(expected[1:], sys.stdall.getvalue())
 
     @mock_streams('both')
@@ -408,17 +408,17 @@ class TestNetwork(FabricTest):
             sudo('oneliner')
             sudo('twoliner')
         expected = """
-[%(prefix)s] sudo: oneliner
-[%(prefix)s] Login password for '%(user)s': 
-[%(prefix)s] out: sudo password:
-[%(prefix)s] out: Sorry, try again.
-[%(prefix)s] out: sudo password: 
-[%(prefix)s] out: result
-[%(prefix)s] sudo: twoliner
-[%(prefix)s] out: sudo password:
-[%(prefix)s] out: result1
-[%(prefix)s] out: result2
-""" % {'prefix': env.host_string, 'user': env.user}
+[{prefix!s}] sudo: oneliner
+[{prefix!s}] Login password for '{user!s}': 
+[{prefix!s}] out: sudo password:
+[{prefix!s}] out: Sorry, try again.
+[{prefix!s}] out: sudo password: 
+[{prefix!s}] out: result
+[{prefix!s}] sudo: twoliner
+[{prefix!s}] out: sudo password:
+[{prefix!s}] out: result1
+[{prefix!s}] out: result2
+""".format(**{'prefix': env.host_string, 'user': env.user})
         eq_(sys.stdall.getvalue(), expected[1:])
 
     @mock_streams('both')
@@ -444,13 +444,13 @@ class TestNetwork(FabricTest):
                 run('normal')
                 run('silent')
         expected = """
-[%(prefix)s] run: normal
-[%(prefix)s] Login password for '%(user)s': 
-[%(prefix)s] out: foo
-[%(prefix)s] run: silent
-[%(prefix)s] run: normal
-[%(prefix)s] out: foo
-""" % {'prefix': env.host_string, 'user': env.user}
+[{prefix!s}] run: normal
+[{prefix!s}] Login password for '{user!s}': 
+[{prefix!s}] out: foo
+[{prefix!s}] run: silent
+[{prefix!s}] run: normal
+[{prefix!s}] out: foo
+""".format(**{'prefix': env.host_string, 'user': env.user})
         eq_(expected[1:], sys.stdall.getvalue())
 
     @mock_streams('both')
@@ -472,13 +472,13 @@ class TestNetwork(FabricTest):
             run('oneliner')
             run('twoliner')
         expected = """
-[%(prefix)s] run: oneliner
-[%(prefix)s] Login password for '%(user)s': 
-[%(prefix)s] out: result
-[%(prefix)s] run: twoliner
-[%(prefix)s] out: result1
-[%(prefix)s] out: result2
-""" % {'prefix': env.host_string, 'user': env.user}
+[{prefix!s}] run: oneliner
+[{prefix!s}] Login password for '{user!s}': 
+[{prefix!s}] out: result
+[{prefix!s}] run: twoliner
+[{prefix!s}] out: result1
+[{prefix!s}] out: result2
+""".format(**{'prefix': env.host_string, 'user': env.user})
         eq_(expected[1:], sys.stdall.getvalue())
 
     @mock_streams('both')
@@ -501,13 +501,13 @@ class TestNetwork(FabricTest):
                 run('oneliner')
                 run('twoliner')
         expected = """
-[%(prefix)s] run: oneliner
-[%(prefix)s] Login password for '%(user)s': 
+[{prefix!s}] run: oneliner
+[{prefix!s}] Login password for '{user!s}': 
 result
-[%(prefix)s] run: twoliner
+[{prefix!s}] run: twoliner
 result1
 result2
-""" % {'prefix': env.host_string, 'user': env.user}
+""".format(**{'prefix': env.host_string, 'user': env.user})
         eq_(expected[1:], sys.stdall.getvalue())
 
     @server()

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -184,7 +184,7 @@ def test_prompt_with_default():
     s = "This is my prompt"
     d = "default!"
     prompt(s, default=d)
-    eq_(sys.stdout.getvalue(), "%s [%s] " % (s, d))
+    eq_(sys.stdout.getvalue(), "{0!s} [{1!s}] ".format(s, d))
 
 
 #
@@ -197,7 +197,7 @@ def test_sudo_prefix_with_user():
     """
     eq_(
         _sudo_prefix(user="foo", group=None),
-        "%s -u \"foo\" " % (env.sudo_prefix % env)
+        "{0!s} -u \"foo\" ".format((env.sudo_prefix % env))
     )
 
 
@@ -214,7 +214,7 @@ def test_sudo_prefix_with_group():
     """
     eq_(
         _sudo_prefix(user=None, group="foo"),
-        "%s -g \"foo\" " % (env.sudo_prefix % env)
+        "{0!s} -g \"foo\" ".format((env.sudo_prefix % env))
     )
 
 
@@ -224,7 +224,7 @@ def test_sudo_prefix_with_user_and_group():
     """
     eq_(
         _sudo_prefix(user="foo", group="bar"),
-        "%s -u \"foo\" -g \"bar\" " % (env.sudo_prefix % env)
+        "{0!s} -u \"foo\" -g \"bar\" ".format((env.sudo_prefix % env))
     )
 
 
@@ -234,15 +234,15 @@ def test_shell_wrap():
     command = "command"
     for description, shell, sudo_prefix, result in (
         ("shell=True, sudo_prefix=None",
-            True, None, '%s "%s"' % (env.shell, command)),
+            True, None, '{0!s} "{1!s}"'.format(env.shell, command)),
         ("shell=True, sudo_prefix=string",
-            True, prefix, prefix + ' %s "%s"' % (env.shell, command)),
+            True, prefix, prefix + ' {0!s} "{1!s}"'.format(env.shell, command)),
         ("shell=False, sudo_prefix=None",
             False, None, command),
         ("shell=False, sudo_prefix=string",
             False, prefix, prefix + " " + command),
     ):
-        eq_.description = "_shell_wrap: %s" % description
+        eq_.description = "_shell_wrap: {0!s}".format(description)
         yield eq_, _shell_wrap(command, shell_escape=True, shell=shell, sudo_prefix=sudo_prefix), result
         del eq_.description
 
@@ -255,7 +255,7 @@ def test_shell_wrap_escapes_command_if_shell_is_true():
     cmd = "cd \"Application Support\""
     eq_(
         _shell_wrap(cmd, shell_escape=True, shell=True),
-        '%s "%s"' % (env.shell, _shell_escape(cmd))
+        '{0!s} "{1!s}"'.format(env.shell, _shell_escape(cmd))
     )
 
 
@@ -267,7 +267,7 @@ def test_shell_wrap_does_not_escape_command_if_shell_is_true_and_shell_escape_is
     cmd = "cd \"Application Support\""
     eq_(
         _shell_wrap(cmd, shell_escape=False, shell=True),
-        '%s "%s"' % (env.shell, cmd)
+        '{0!s} "{1!s}"'.format(env.shell, cmd)
     )
 
 
@@ -576,7 +576,7 @@ class TestFileTransfers(FabricTest):
             fd.write("foo")
         with hide('stdout', 'running'):
             get(target, local)
-        assert "%s already exists" % local in sys.stderr.getvalue()
+        assert "{0!s} already exists".format(local) in sys.stderr.getvalue()
         eq_contents(local, FILES[target])
 
     @server()
@@ -596,11 +596,11 @@ class TestFileTransfers(FabricTest):
     @server(port=2201)
     def test_get_from_multiple_servers(self):
         ports = [2200, 2201]
-        hosts = map(lambda x: '127.0.0.1:%s' % x, ports)
+        hosts = map(lambda x: '127.0.0.1:{0!s}'.format(x), ports)
         with settings(all_hosts=hosts):
             for port in ports:
                 with settings(
-                    hide('everything'), host_string='127.0.0.1:%s' % port
+                    hide('everything'), host_string='127.0.0.1:{0!s}'.format(port)
                 ):
                     tmp = self.path('')
                     local_path = os.path.join(tmp, "%(host)s", "%(path)s")
@@ -608,12 +608,12 @@ class TestFileTransfers(FabricTest):
                     path = 'file.txt'
                     get(path, local_path)
                     assert self.exists_locally(os.path.join(
-                        tmp, "127.0.0.1-%s" % port, path
+                        tmp, "127.0.0.1-{0!s}".format(port), path
                     ))
                     # Nested file
                     get('tree/subfolder/file3.txt', local_path)
                     assert self.exists_locally(os.path.join(
-                        tmp, "127.0.0.1-%s" % port, 'file3.txt'
+                        tmp, "127.0.0.1-{0!s}".format(port), 'file3.txt'
                     ))
 
     @server()
@@ -732,13 +732,13 @@ class TestFileTransfers(FabricTest):
         # the sha1 hash is the unique filename of the file being downloaded. sha1(<filename>)
         name = "229a29e5693876645e39de0cb0532e43ad73311a"
         fake_run = Fake('_run_command', callable=True, expect_call=True).with_matching_args(
-            'cp -p "/etc/apache2/apache2.conf" "%s"' % name, True, True, None,
+            'cp -p "/etc/apache2/apache2.conf" "{0!s}"'.format(name), True, True, None,
         ).next_call().with_matching_args(
-            'chown username "%s"' % name, True, True, None,
+            'chown username "{0!s}"'.format(name), True, True, None,
         ).next_call().with_matching_args(
-            'chmod 400 "%s"' % name, True, True, None,
+            'chmod 400 "{0!s}"'.format(name), True, True, None,
         ).next_call().with_matching_args(
-            'rm -f "%s"' % name, True, True, None,
+            'rm -f "{0!s}"'.format(name), True, True, None,
         )
         fake_get = Fake('get', callable=True, expect_call=True).with_args(
             name, fudge_arg.any_value())
@@ -759,16 +759,16 @@ class TestFileTransfers(FabricTest):
         # the sha1 hash is the unique filename of the file being downloaded. sha1(<filename>)
         name = "229a29e5693876645e39de0cb0532e43ad73311a"
         fake_run = Fake('_run_command', callable=True, expect_call=True).with_matching_args(
-            'cp -p "/etc/apache2/apache2.conf" "/tmp/%s"' % name, True, True, None,
+            'cp -p "/etc/apache2/apache2.conf" "/tmp/{0!s}"'.format(name), True, True, None,
         ).next_call().with_matching_args(
-            'chown username "/tmp/%s"' % name, True, True, None,
+            'chown username "/tmp/{0!s}"'.format(name), True, True, None,
         ).next_call().with_matching_args(
-            'chmod 400 "/tmp/%s"' % name, True, True, None,
+            'chmod 400 "/tmp/{0!s}"'.format(name), True, True, None,
         ).next_call().with_matching_args(
-            'rm -f "/tmp/%s"' % name, True, True, None,
+            'rm -f "/tmp/{0!s}"'.format(name), True, True, None,
         )
         fake_get = Fake('get', callable=True, expect_call=True).with_args(
-            '/tmp/%s' % name, fudge_arg.any_value())
+            '/tmp/{0!s}'.format(name), fudge_arg.any_value())
 
         with hide('everything'):
             with patched_context('fabric.operations', '_run_command', fake_run):
@@ -982,7 +982,7 @@ class TestFileTransfers(FabricTest):
             fd.write('test')
         with nested(cd(d), hide('everything')):
             put(local, f)
-        assert self.exists_remotely('%s/%s' % (d, f))
+        assert self.exists_remotely('{0!s}/{1!s}'.format(d, f))
 
     @server(files={'/tmp/test.txt': 'test'})
     def test_cd_should_apply_to_get(self):
@@ -1030,7 +1030,7 @@ class TestFileTransfers(FabricTest):
             fd.write("contents")
         with nested(lcd(self.path(d)), hide('everything')):
             put(f, '/')
-        assert self.exists_remotely('/%s' % f)
+        assert self.exists_remotely('/{0!s}'.format(f))
 
     @server()
     def test_lcd_should_apply_to_get(self):
@@ -1082,7 +1082,7 @@ def test_local_output_and_capture():
                 else:
                     shows.append('stderr')
                 with nested(hide(*hides), show(*shows)):
-                    d = "local(): capture: %r, stdout: %r, stderr: %r" % (
+                    d = "local(): capture: {0!r}, stdout: {1!r}, stderr: {2!r}".format(
                         capture, stdout, stderr
                     )
                     local.description = d

--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -34,7 +34,7 @@ class TestParallel(FabricTest):
             assert USER not in env.host
             assert str(PORT) not in env.host
 
-        host_string = '%s@%s:%%s' % (USER, HOST)
+        host_string = '{0!s}@{1!s}:%s'.format(USER, HOST)
         with hide('everything'):
             execute(_task, hosts=[host_string % 2200, host_string % 2201])
 

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -88,7 +88,7 @@ class UploadProjectTestCase(unittest.TestCase):
         # local() is called more than once so we need an extra next_call()
         # otherwise fudge compares the args to the last call to local()
         self.fake_local.with_args(
-            arg.endswith("-C %s %s" % (cwd_path, cwd_name))
+            arg.endswith("-C {0!s} {1!s}".format(cwd_path, cwd_name))
         ).next_call()
 
         # Exercise
@@ -104,7 +104,7 @@ class UploadProjectTestCase(unittest.TestCase):
         # local() is called more than once so we need an extra next_call()
         # otherwise fudge compares the args to the last call to local()
         self.fake_local.with_args(
-            arg.endswith("-C %s %s" % os.path.split(project_path))
+            arg.endswith("-C {0!s} {1!s}".format(*os.path.split(project_path)))
         ).next_call()
 
         # Exercise
@@ -121,11 +121,11 @@ class UploadProjectTestCase(unittest.TestCase):
         # local() is called more than once so we need an extra next_call()
         # otherwise fudge compares the args to the last call to local()
         self.fake_local.with_args(
-            arg.endswith("-C %s %s" % (project_path, base))
+            arg.endswith("-C {0!s} {1!s}".format(project_path, base))
         ).next_call()
 
         # Exercise
-        project.upload_project(local_dir="%s/%s/" % (project_path, base))
+        project.upload_project(local_dir="{0!s}/{1!s}/".format(project_path, base))
 
 
     @fudge.with_fakes
@@ -137,7 +137,7 @@ class UploadProjectTestCase(unittest.TestCase):
         # local() is called more than once so we need an extra next_call()
         # otherwise fudge compares the args to the last call to local()
         self.fake_put.with_args(
-            "%s/folder.tar.gz" % self.fake_tmp, "folder.tar.gz", use_sudo=False
+            "{0!s}/folder.tar.gz".format(self.fake_tmp), "folder.tar.gz", use_sudo=False
         ).next_call()
 
         # Exercise
@@ -153,7 +153,7 @@ class UploadProjectTestCase(unittest.TestCase):
         # local() is called more than once so we need an extra next_call()
         # otherwise fudge compares the args to the last call to local()
         self.fake_put.with_args(
-            "%s/folder.tar.gz" % self.fake_tmp, "%s/folder.tar.gz" % remote_path, use_sudo=False
+            "{0!s}/folder.tar.gz".format(self.fake_tmp), "{0!s}/folder.tar.gz".format(remote_path), use_sudo=False
         ).next_call()
 
         # Exercise

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -93,6 +93,6 @@ def test_list_folder():
         # Grab filename from SFTPAttribute objects in result
         output = map(lambda x: x.filename, results)
         # Yield test generator
-        eq_.description = "list_folder: %s" % desc
+        eq_.description = "list_folder: {0!s}".format(desc)
         yield eq_, set(expected), set(output)
         del eq_.description

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -40,7 +40,7 @@ class TestWrappedCallableTask(unittest.TestCase):
 
     def test_passes_unused_kwargs_to_parent(self):
         random_range = range(random.randint(1, 10))
-        kwargs = {"key_%s" % i: i for i in random_range}
+        kwargs = {"key_{0!s}".format(i): i for i in random_range}
 
         def foo(): pass
         try:
@@ -55,7 +55,7 @@ class TestWrappedCallableTask(unittest.TestCase):
         task = WrappedCallableTask(foo, *args)
 
     def test_allows_any_number_of_kwargs(self):
-        kwargs = {"key%d" % i: i for i in range(random.randint(0, 10))}
+        kwargs = {"key{0:d}".format(i): i for i in range(random.randint(0, 10))}
         def foo(): pass
         task = WrappedCallableTask(foo, **kwargs)
 
@@ -66,7 +66,7 @@ class TestWrappedCallableTask(unittest.TestCase):
 
     def test_name_is_the_name_of_the_wrapped_callable(self):
         def foo(): pass
-        foo.__name__ = "random_name_%d" % random.randint(1000, 2000)
+        foo.__name__ = "random_name_{0:d}".format(random.randint(1000, 2000))
         task = WrappedCallableTask(foo)
         eq_(task.name, foo.__name__)
 
@@ -77,12 +77,12 @@ class TestWrappedCallableTask(unittest.TestCase):
 
     def test_reads_double_under_doc_from_callable(self):
         def foo(): pass
-        foo.__doc__ = "Some random __doc__: %d" % random.randint(1000, 2000)
+        foo.__doc__ = "Some random __doc__: {0:d}".format(random.randint(1000, 2000))
         task = WrappedCallableTask(foo)
         eq_(task.__doc__, foo.__doc__)
 
     def test_dispatches_to_wrapped_callable_on_run(self):
-        random_value = "some random value %d" % random.randint(1000, 2000)
+        random_value = "some random value {0:d}".format(random.randint(1000, 2000))
         def foo(): return random_value
         task = WrappedCallableTask(foo)
         eq_(random_value, task())
@@ -113,12 +113,12 @@ class TestWrappedCallableTask(unittest.TestCase):
 
 class TestTask(unittest.TestCase):
     def test_takes_an_alias_kwarg_and_wraps_it_in_aliases_list(self):
-        random_alias = "alias_%d" % random.randint(100, 200)
+        random_alias = "alias_{0:d}".format(random.randint(100, 200))
         task = Task(alias=random_alias)
         self.assertTrue(random_alias in task.aliases)
 
     def test_aliases_are_set_based_on_provided_aliases(self):
-        aliases = ["a_%d" % i for i in range(random.randint(1, 10))]
+        aliases = ["a_{0:d}".format(i) for i in range(random.randint(1, 10))]
         task = Task(aliases=aliases)
         self.assertTrue(all(a in task.aliases for a in aliases))
 
@@ -353,7 +353,7 @@ class TestExecute(FabricTest):
         Networked but serial tasks should return per-host-string dict
         """
         ports = [2200, 2201]
-        hosts = map(lambda x: '127.0.0.1:%s' % x, ports)
+        hosts = map(lambda x: '127.0.0.1:{0!s}'.format(x), ports)
         def task():
             run("ls /simple")
             return "foo"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -35,7 +35,7 @@ def test_indent():
         ("List of strings turns in to strings joined by \\n",
             ["Test", "Test"], '    Test\n    Test'),
     ):
-        eq_.description = "indent(): %s" % description
+        eq_.description = "indent(): {0!s}".format(description)
         yield eq_, indent(input), output
         del eq_.description
 
@@ -50,7 +50,7 @@ def test_indent_with_strip():
             indent(["        Test", "        Test"], strip=True),
             '    Test\n    Test'),
     ):
-        eq_.description = "indent(strip=True): %s" % description
+        eq_.description = "indent(strip=True): {0!s}".format(description)
         yield eq_, input, output
         del eq_.description
 
@@ -163,7 +163,7 @@ def test_puts_with_prefix():
     h = "localhost"
     with settings(host_string=h):
         puts(s)
-    eq_(sys.stdout.getvalue(), "[%s] %s" % (h, s + "\n"))
+    eq_(sys.stdout.getvalue(), "[{0!s}] {1!s}".format(h, s + "\n"))
 
 
 @mock_streams('stdout')
@@ -174,7 +174,7 @@ def test_puts_without_prefix():
     s = "my output"
     h = "localhost"
     puts(s, show_prefix=False)
-    eq_(sys.stdout.getvalue(), "%s" % (s + "\n"))
+    eq_(sys.stdout.getvalue(), "{0!s}".format((s + "\n")))
 
 @with_fakes
 def test_fastprint_calls_puts():

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -46,7 +46,7 @@ class FabricTest(object):
         self.tmpdir = tempfile.mkdtemp()
 
     def set_network(self):
-        env.update(to_dict('%s@%s:%s' % (USER, HOST, PORT)))
+        env.update(to_dict('{0!s}@{1!s}:{2!s}'.format(USER, HOST, PORT)))
 
     def env_setup(self):
         # Set up default networking for test server
@@ -127,7 +127,7 @@ def password_response(password, times_called=None, silent=True):
 def _assert_contains(needle, haystack, invert):
     matched = re.search(needle, haystack, re.M)
     if (invert and matched) or (not invert and not matched):
-        raise AssertionError("r'%s' %sfound in '%s'" % (
+        raise AssertionError("r'{0!s}' {1!s}found in '{2!s}'".format(
             needle,
             "" if invert else "not ",
             haystack
@@ -154,18 +154,18 @@ def eq_(result, expected, msg=None):
 --------------------------------- aka -----------------------------------------
 
 Expected:
-%(expected)r
+{expected!r}
 
 Got:
-%(result)r
-""" % params
+{result!r}
+""".format(**params)
     default_msg = """
 Expected:
-%(expected)s
+{expected!s}
 
 Got:
-%(result)s
-""" % params
+{result!s}
+""".format(**params)
     if (repr(result) != str(result)) or (repr(expected) != str(expected)):
         default_msg += aka
     assert result == expected, msg or default_msg


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:fabric?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:fabric?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
